### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requirements
 ------------
 
 ```
-sudo apt install zsh edid-decode automake
+sudo apt install zsh edid-decode automake dos2unix
 ```
 
 Usage


### PR DESCRIPTION
Add dos2unix as a builddep, as compiling will otherwise fail with the error message "Makefile:32: recipe for target 'x.bin.ihex' failed".