### PR TITLE
leading spaces causing failed match in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ clean:
 
 %.crc:	%.bin.nocrc
 	cat $^ | edid-decode \
-		| sed -ne 's/^Checksum: 0x\w\+ (should be \(0x\w\+\))$$/\1/p' >$@
+		| sed -ne 's/^[ ]*Checksum: 0x\w\+ (should be \(0x\w\+\))$$/\1/p' >$@
 
 %.p:	%.crc %.S
 	cc -c -DCRC="$$(cat $*.crc)" -o $@ $*.S

--- a/modeline2edid
+++ b/modeline2edid
@@ -38,33 +38,31 @@ template-S() {
 
 	local -A defines
 	defines=(
-		TIMING_NAME "${(qqq)name}"
-
-		CLOCK   "$pixel_clock_khz"
-		XPIX    "$hdisp"
-		XBLANK  "$((htotal - hdisp))"
-		XOFFSET "$((hsyncstart - hdisp))"
-		XPULSE  "$((hsyncend - hsyncstart))"
-
-		YPIX    "$vdisp"
-		YBLANK  "$((vtotal - vdisp))"
-		YOFFSET "(63+$((vsyncstart - vdisp)))"
-		YPULSE  "(63+$((vsyncend - vsyncstart)))"
-
 		VERSION "${edid_version%%.*}"
 		REVISION "${edid_version#*.}"
-
+		CLOCK   "$pixel_clock_khz"
+		XPIX    "$hdisp"
+		YPIX    "$vdisp"
 		XY_RATIO "XY_RATIO_${(U)ratio//:/_}"
+		XBLANK  "$((htotal - hdisp))"
+		YBLANK  "$((vtotal - vdisp))"
+		XOFFSET "$((hsyncstart - hdisp))"
+		XPULSE  "$((hsyncend - hsyncstart))"
+		YOFFSET "(63+$((vsyncstart - vdisp)))"
+		YPULSE  "(63+$((vsyncend - vsyncstart)))"
 		DPI "$dpi"
 		VFREQ "$vfreq_hz"
+                TIMING_NAME "${(qqq)name}"
 		HSYNC_POL "$hsync_polarity"
 		VSYNC_POL "$vsync_polarity"
 	)
 
-	local -a lines=('/* '"$name: $REPLY"' */')
+        lines=('/* '"$name: $REPLY"' */') # removed local -a
 	local k
-	for k in ${(k)defines}; do
+	for k in "${(@k)defines}"; do
 		lines+=("#define $k ${defines[$k]}")
+                #echo ${defines[TIMING_NAME]}
+                #echo "#define $k ${defines[$k]}"
 	done
 	lines+=('#include "edid.S"')
 

--- a/modeline2edid
+++ b/modeline2edid
@@ -57,12 +57,11 @@ template-S() {
 		VSYNC_POL "$vsync_polarity"
 	)
 
-        lines=('/* '"$name: $REPLY"' */') # removed local -a
+        local lines=('/* '"$name: $REPLY"' */') # removed -a option
 	local k
 	for k in "${(@k)defines}"; do
 		lines+=("#define $k ${defines[$k]}")
-                #echo ${defines[TIMING_NAME]}
-                #echo "#define $k ${defines[$k]}"
+
 	done
 	lines+=('#include "edid.S"')
 


### PR DESCRIPTION
There was a problem with the Makefile that caused incorrect checksum during file creations.
The version of edid-decode I'm using has leading spaces in front of the word "Checksum" causing the line not to match " Checksum" and extracting the correct checksum.

removed local -a   from the following line.
local -a lines=('/* '"$name: $REPLY"' */') #