### PR TITLE
avoid hiding stderr from dos2unix to make it easier to notice problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ clean:
 
 %.bin.ihex:	%.p
 	objcopy -Oihex $^ $@
-	dos2unix $@ 2>/dev/null
+	dos2unix --quiet $@
 
 %.c:	%.bin
 	@echo "{" >$@; hexdump -f hex $^ >>$@; echo "};" >>$@


### PR DESCRIPTION
Now the output will end like this when silly people like me forget to install dos2unix like at https://github.com/akatrevorjay/edid-generator/issues/5#issuecomment-371862456:

```console
$ make
...snip...
cc -c -DCRC="$(cat 1600x1200.crc)" -o 1600x1200.p 1600x1200.S
objcopy -Oihex 1600x1200.p 1600x1200.bin.ihex
dos2unix --quiet 1600x1200.bin.ihex
make: dos2unix: Command not found
make: *** [Makefile:33: 1600x1200.bin.ihex] Error 127
rm 1920x1080x120.00.bin.nocrc 1600x1200.bin.nocrc 1920x1080x120.00.crc 1600x1200.crc 1600x1200.p 1920x1080x120.00.o 1600x1200.o 1920x1080x120.00.p
```