### PR TITLE
Fix "EDID length 127 is not a multiple of 128"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ clean:
 	cc -c -DCRC="0x00" -o $@ $^
 
 %.bin.nocrc:	%.o
-	objcopy -Obinary $^ $@
+	objcopy -j .data -Obinary $^ $@
 
 %.crc:	%.bin.nocrc
 	cat $^ | edid-decode \
@@ -26,7 +26,7 @@ clean:
 	cc -c -DCRC="$$(cat $*.crc)" -o $@ $*.S
 
 %.bin:	%.p
-	objcopy -Obinary $^ $@
+	objcopy -j .data -Obinary $^ $@
 
 %.bin.ihex:	%.p
 	objcopy -Oihex $^ $@


### PR DESCRIPTION
Fix issue EDID bin length issue that apperead on recent versions of gcc or objcopy (see gh-21). The fix has been originally suggested by marwanramadan.