### PR TITLE
allow more descriptive filenames (make SOURCES)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-SOURCES	:= $(wildcard [0-9]*x[0-9]*.S)
+SOURCES	:= $(wildcard *[0-9]*x[0-9]**.S)
 
 BIN	:= $(patsubst %.S, %.bin, $(SOURCES))
 


### PR DESCRIPTION
I am not sure what is the reasoning behind allowing only `1234x578.S` in a `Makefile`, but I could use this change upstream due to my usage for multiple monitors in NixOS: 
- https://github.com/nazarewk-iac/nix-configs/blob/ecb36b01f4df3b1bd148eeda58f8a9e74f7c4b57/modules/hardware/edid/default.nix#L15-L22
- my patch: https://github.com/nazarewk-iac/nix-configs/blob/ecb36b01f4df3b1bd148eeda58f8a9e74f7c4b57/packages/edid-generator/default.nix#L37-L38
