### PR TITLE
stop ignoring validation errors

### DIFF
--- a/modeline2edid
+++ b/modeline2edid
@@ -121,9 +121,13 @@ if [[ -z "$f" || "$f" == "-h" ]]; then
 fi
 
 echo "Searching for modelines in '$f'"
+retcode=0
 while read; do
 	# trim
 	REPLY=($=REPLY)
 	[[ -n "$REPLY" ]] || continue
-	template-S ${(@)REPLY} || :
+	if ! template-S ${(@)REPLY} ; then
+		retcode=1
+	fi
 done < $f
+exit $retcode


### PR DESCRIPTION
While preparing an update for `nixpkgs` package I noticed validation errors are simply ignored.

Could you quickly merge it while you're here @akatrevorjay ?